### PR TITLE
add default value to pos select 

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,8 @@
     <li class=word>
       <p class=wordToken></p>
       <p class=wordGloss contenteditable></p>
-      <select class=wordPOS>
+      <select class=wordPOS selected=''>
+        <option value=''>p.o.s.</option>
         <option value=noun>n.</option>
         <option value=verb>v.</option>
         <option value=adjective>adj.</option>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       <p class=wordToken></p>
       <p class=wordGloss contenteditable></p>
       <select class=wordPOS selected=''>
-        <option value=''>p.o.s.</option>
+        <option value=''>part of speech</option>
         <option value=noun>n.</option>
         <option value=verb>v.</option>
         <option value=adjective>adj.</option>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       <p class=wordToken></p>
       <p class=wordGloss contenteditable></p>
       <select class=wordPOS selected=''>
-        <option value=''>part of speech</option>
+        <option selected disabled value=''>part of speech</option>
         <option value=noun>n.</option>
         <option value=verb>v.</option>
         <option value=adjective>adj.</option>


### PR DESCRIPTION
default dispaly value is now `part of speech` and it is disabled so after you open the selector you have to select one of the other values; otherwise, the default data value is empty `''`